### PR TITLE
Only use public visibility when needed

### DIFF
--- a/src/Module.h
+++ b/src/Module.h
@@ -9,7 +9,7 @@ public:
   const char * name;
   bool success;
   bool enabled;
-  unsigned long secondMillis = 0;
+  unsigned long secondMillis = 0; // Feels like it should be private, bit doesn't compile if set as such
 
   JsonObject parentObject;
 

--- a/src/Modules.h
+++ b/src/Modules.h
@@ -3,8 +3,10 @@
 #include <vector>
 
 class Modules {
-public:
-  std::vector<Module *> modules;
+  private:
+    std::vector<Module *> modules;
+
+  public:
 
   void setup() {
       for (Module *module:modules) module->setup();
@@ -22,8 +24,8 @@ public:
     }
   }
 
-  void add (Module module) {
-    // modules.push_back(module);
+  void add (Module* module) {
+    modules.push_back(module);
   }
 
   void connected() {

--- a/src/SysModFiles.cpp
+++ b/src/SysModFiles.cpp
@@ -113,3 +113,7 @@ void SysModFiles::dirToJson2(JsonArray array) {
     file = root.openNextFile();
   }
 }
+
+void SysModFiles::filesChange() {
+  filesChanged = true;
+}

--- a/src/SysModFiles.h
+++ b/src/SysModFiles.h
@@ -6,7 +6,6 @@ class SysModFiles:public Module {
 
 public:
 
-  static bool filesChanged;
 
   SysModFiles();
   void setup();
@@ -22,8 +21,13 @@ public:
 
   File open(const char * path, const char * mode, const bool create = false);
 
+  void filesChange();
+
   static void dirToJson(JsonArray array);
   static void dirToJson2(JsonArray array);
+
+private:
+  static bool filesChanged;
 
 };
 

--- a/src/SysModModel.cpp
+++ b/src/SysModModel.cpp
@@ -140,7 +140,7 @@ bool SysModModel::writeObjectToFile(const char* path, JsonDocument* dest) {
   if (f) {
     print->println(F("  success"));
     serializeJson(*dest, f);
-    files->filesChanged = true;
+    files->filesChange();
     return true;
   } else {
     f.close();

--- a/src/SysModModel.h
+++ b/src/SysModModel.h
@@ -6,9 +6,6 @@
 class SysModModel:public Module {
 
 public:
-  static bool doWriteModel;
-  static bool doShowObsolete;
-  bool cleanUpModelDone = false;
 
   // StaticJsonDocument<24576> model; //not static as that blows up the stack. Use extern??
   static DynamicJsonDocument *model;
@@ -45,6 +42,11 @@ public:
 
   //returns the object defined by id (parent to recursively call findObject)
   static JsonObject findObject(const char * id, JsonArray parent = JsonArray());
+  
+private:
+  static bool doWriteModel;
+  static bool doShowObsolete;
+  bool cleanUpModelDone = false;
 
 };
 

--- a/src/SysModNetwork.h
+++ b/src/SysModNetwork.h
@@ -5,16 +5,6 @@
 class SysModNetwork:public Module {
 
 public:
-  bool apActive = false;
-  uint32_t lastReconnectAttempt = 0;
-  char apSSID[33] = "StarMod AP";
-  char apPass[65] = "star1234";
-  byte apChannel = 1; // 2.4GHz WiFi AP channel (1-13)
-  byte apHide    = 0; // hidden AP SSID
-  bool interfacesInited = false;
-  static bool forceReconnect;
-  DNSServer dnsServer;
-  bool noWifiSleep = true;
 
   SysModNetwork();
 
@@ -28,6 +18,18 @@ public:
   void initConnection();
 
   void initAP();
+  
+private:
+  bool apActive = false;
+  uint32_t lastReconnectAttempt = 0;
+  char apSSID[33] = "StarMod AP";
+  char apPass[65] = "star1234";
+  byte apChannel = 1; // 2.4GHz WiFi AP channel (1-13)
+  byte apHide    = 0; // hidden AP SSID
+  bool interfacesInited = false;
+  static bool forceReconnect;
+  DNSServer dnsServer;
+  bool noWifiSleep = true;
 
 };
   

--- a/src/SysModSystem.h
+++ b/src/SysModSystem.h
@@ -6,11 +6,13 @@ class SysModSystem:public Module {
 
 public:
 
-  unsigned long loopCounter = 0;
-
   SysModSystem();
   void setup();
   void loop();
+
+
+private:
+  unsigned long loopCounter = 0;
 
   void addResetReasonsLov(JsonArray lov);
 

--- a/src/SysModUI.h
+++ b/src/SysModUI.h
@@ -20,11 +20,6 @@ struct UserLoop {
 class SysModUI:public Module {
 
 public:
-// TODO: which of these fields should be private?
-  static std::vector<USFun> uiFunctions;
-  static std::vector<UserLoop> loopFunctions;
-
-
   SysModUI();
 
   //serve index.htm
@@ -68,6 +63,9 @@ private:
   static bool userLoopsChanged;
 
   static int objectCounter; //not static crashes ??? (not called async...?)
+
+  static std::vector<USFun> uiFunctions;
+  static std::vector<UserLoop> loopFunctions;
 
 };
 

--- a/src/SysModUI.h
+++ b/src/SysModUI.h
@@ -24,9 +24,6 @@ public:
   static std::vector<USFun> uiFunctions;
   static std::vector<UserLoop> loopFunctions;
 
-  static bool userLoopsChanged;
-
-  static int objectCounter; //not static crashes ??? (not called async...?)
 
   SysModUI();
 
@@ -66,6 +63,11 @@ public:
   static const char * processJson(JsonVariant &json);
 
   void processUiFun(const char * id);
+
+private:
+  static bool userLoopsChanged;
+
+  static int objectCounter; //not static crashes ??? (not called async...?)
 
 };
 

--- a/src/SysModUI.h
+++ b/src/SysModUI.h
@@ -20,6 +20,7 @@ struct UserLoop {
 class SysModUI:public Module {
 
 public:
+// TODO: which of these fields should be private?
   static std::vector<USFun> uiFunctions;
   static std::vector<UserLoop> loopFunctions;
 

--- a/src/SysModWeb.cpp
+++ b/src/SysModWeb.cpp
@@ -334,7 +334,7 @@ bool SysModWeb::addUpload(const char * uri) {
           request->send(200, "text/plain", F("File Uploaded!"));
       // }
       // cacheInvalidate++;
-      files->filesChanged = true;
+     files->filesChange();
     }
   });
   return true;

--- a/src/SysModWeb.cpp
+++ b/src/SysModWeb.cpp
@@ -71,9 +71,9 @@ void SysModWeb::loop() {
   // Module::loop();
 
   //currently not used as each variable is send individually
-  if (modelUpdated) {
+  if (this->modelUpdated) {
     sendDataWs(nullptr, false); //send new data, all clients, no def
-    modelUpdated = false;
+    this->modelUpdated = false;
   }
 
   if (millis() - secondMillis >= 1000 || !secondMillis) {

--- a/src/SysModWeb.h
+++ b/src/SysModWeb.h
@@ -7,9 +7,7 @@ class SysModWeb:public Module {
 
 public:
 // TODO: which of these fields should be private?
-  static AsyncWebServer *server;
   static AsyncWebSocket *ws;
-  static const char * (*processWSFunc)(JsonVariant &);
   static DynamicJsonDocument *responseDoc0;
   static DynamicJsonDocument *responseDoc1;
 
@@ -63,6 +61,9 @@ public:
 private:
   bool modelUpdated = false;
   static bool clientsChanged;
+
+  static AsyncWebServer *server;
+  static const char * (*processWSFunc)(JsonVariant &);
 
 };
 

--- a/src/SysModWeb.h
+++ b/src/SysModWeb.h
@@ -6,6 +6,7 @@
 class SysModWeb:public Module {
 
 public:
+// TODO: which of these fields should be private?
   bool modelUpdated = false;
   static bool clientsChanged;
   static AsyncWebServer *server;

--- a/src/SysModWeb.h
+++ b/src/SysModWeb.h
@@ -7,8 +7,6 @@ class SysModWeb:public Module {
 
 public:
 // TODO: which of these fields should be private?
-  bool modelUpdated = false;
-  static bool clientsChanged;
   static AsyncWebServer *server;
   static AsyncWebSocket *ws;
   static const char * (*processWSFunc)(JsonVariant &);
@@ -61,6 +59,10 @@ public:
   void addResponseInt(JsonObject object, const char * key, int value);
   void addResponseBool(JsonObject object, const char * key, bool value);
   JsonArray addResponseArray(JsonObject object, const char * key);
+
+private:
+  bool modelUpdated = false;
+  static bool clientsChanged;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,15 +27,15 @@ void setup() {
   pin = new AppModPinManager();
   lds = new AppModLeds();
 
-  mdls->modules.push_back(print);
-  mdls->modules.push_back(files);
-  mdls->modules.push_back(mdl);
-  mdls->modules.push_back(net);
-  mdls->modules.push_back(web);
-  mdls->modules.push_back(ui);
-  mdls->modules.push_back(sys);
-  mdls->modules.push_back(pin);
-  mdls->modules.push_back(lds);
+  mdls->add(print);
+  mdls->add(files);
+  mdls->add(mdl);
+  mdls->add(net);
+  mdls->add(web);
+  mdls->add(ui);
+  mdls->add(sys);
+  mdls->add(pin);
+  mdls->add(lds);
 
   mdls->setup();
 }


### PR DESCRIPTION
To prevent spaghetti code, better to hide access to as much of the state of each module to be private and provide methods to read/update only through the proper interface