### PR TITLE
Adding pre compile script to clone submodules

### DIFF
--- a/pio-scripts/recursive_clone.py
+++ b/pio-scripts/recursive_clone.py
@@ -1,0 +1,3 @@
+import os
+os.system("git submodule update --init --recursive")
+

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,6 +8,10 @@
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
 
+[scripts_defaults]
+extra_scripts =
+  pre:pio-scripts/recursive_clone.py
+
 [env:esp32dev]
 platform = espressif32
 board = esp32dev
@@ -15,3 +19,4 @@ framework = arduino
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 board_build.filesystem = littlefs
+extra_scripts = ${scripts_defaults.extra_scripts}


### PR DESCRIPTION
Adding a small pre script with `git submodule update --init --recursive` will take care of getting the submodules, before the build starts and failing cause the submodules are not there.

(and making it more user friendly for people that havent used submodules before)