### PR TITLE
Esp32-S2 - solve regular serial disconnects

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -7,6 +7,11 @@
 ;    @license   GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
 ;    @license   For non GPL-v3 usage, commercial licenses must be purchased. Contact moonmodules@icloud.com
 
+;; [env]
+;; framework = arduino
+;; monitor_speed = 115200
+;; upload_speed = 115200
+
 [starmod]
 lib_deps =
     https://github.com/bblanchon/ArduinoJson.git#v6.21.4
@@ -45,7 +50,8 @@ lib_deps =
 
 [env:esp32dev]
 board = esp32dev ;https://github.com/platformio/platform-espressif32/blob/develop/boards/esp32dev.json
-platform = espressif32 ;using platformio/framework-arduinoespressif32 @ ~3.20014.0 / framework-arduinoespressif32 @ 3.20014.231204 (2.0.14) 
+; recommended to pin to a platform version, see https://github.com/platformio/platform-espressif32/releases
+platform = espressif32@6.5.0 ;using platformio/framework-arduinoespressif32 @ ~3.20014.0 / framework-arduinoespressif32 @ 3.20014.231204 (2.0.14)
 framework = arduino
 upload_speed = 1500000
 monitor_speed = 115200
@@ -56,6 +62,8 @@ board_build.flash_mode = dio ; (dio = dual i/o; more compatible than qio = quad 
 build_flags = 
   -DCONFIG_IDF_TARGET_ESP32=1
   -DCONFIG_ASYNC_TCP_USE_WDT=0
+  -DLFS_THREADSAFE            ;; enables use of semaphores in LittleFS driver
+  -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
   ${appmod_leds.build_flags}
   ${usermod_e131.build_flags}
   ; ${usermod_ha.build_flags}
@@ -78,9 +86,13 @@ monitor_speed = 115200
 board_build.partitions = tools/WLED_ESP32_4MB_256KB_FS.csv   ;; 1.8MB firmware, 256KB filesystem (esptool erase_flash needed when changing from "standard WLED" partitions)
 monitor_filters = esp32_exception_decoder
 board_build.filesystem = littlefs
-build_flags = 
+build_flags =
   -DCONFIG_IDF_TARGET_ESP32S2=1
   -DCONFIG_ASYNC_TCP_USE_WDT=0
+  -DLFS_THREADSAFE            ;; enables use of semaphores in LittleFS driver
+  -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; for debugging over USB
+  ; -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; without USB debug (use in case your board hangs without USB connection)
+  -DARDUINO_USB_MODE=0        ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (mandatory on -S2)
   ${appmod_leds.build_flags}
   ${usermod_e131.build_flags}
   ; ${usermod_ha.build_flags}

--- a/src/App/AppLedsV.h
+++ b/src/App/AppLedsV.h
@@ -9,6 +9,14 @@
    @license   For non GPL-v3 usage, commercial licenses must be purchased. Contact moonmodules@icloud.com
 */
 
+// FastLED optional flags to configure drivers, see https://github.com/FastLED/FastLED/blob/master/src/platforms/esp/32
+// RMT driver (default)
+// #define FASTLED_ESP32_FLASH_LOCK 1    // temporarily disabled FLASH file access while driving LEDs (may prevent random flicker)
+// #define FASTLED_RMT_BUILTIN_DRIVER 1  // in case your app needs to use RMT units, too (slower)
+// I2S parallel driver
+// #define FASTLED_ESP32_I2S true        // to use I2S parallel driver (instead of RMT)
+// #define I2S_DEVICE 1                  // I2S driver: allows to still use I2S#0 for audio (only on esp32 and esp32-s3)
+// #define FASTLED_I2S_MAX_CONTROLLERS 8 // 8 LED pins should be enough (default = 24)
 #include "FastLED.h"
 #include <vector>
 #include "ArduinoJson.h"

--- a/src/App/AppModLeds.h
+++ b/src/App/AppModLeds.h
@@ -18,6 +18,14 @@
 #endif
 
 #include <vector>
+// FastLED optional flags to configure drivers, see https://github.com/FastLED/FastLED/blob/master/src/platforms/esp/32
+// RMT driver (default)
+// #define FASTLED_ESP32_FLASH_LOCK 1    // temporarily disabled FLASH file access while driving LEDs (may prevent random flicker)
+// #define FASTLED_RMT_BUILTIN_DRIVER 1  // in case your app needs to use RMT units, too (slower)
+// I2S parallel driver
+// #define FASTLED_ESP32_I2S true        // to use I2S parallel driver (instead of RMT)
+// #define I2S_DEVICE 1                  // I2S driver: allows to still use I2S#0 for audio (only on esp32 and esp32-s3)
+// #define FASTLED_I2S_MAX_CONTROLLERS 8 // 8 LED pins should be enough (default = 24)
 #include "FastLED.h"
 
 // #define FASTLED_RGBW

--- a/src/Sys/SysModPrint.cpp
+++ b/src/Sys/SysModPrint.cpp
@@ -19,7 +19,25 @@ SysModPrint::SysModPrint() :SysModule("Print") {
   // print("%s %s\n", __PRETTY_FUNCTION__, name);
 
   Serial.begin(115200);
-  delay(5000); //if (!Serial) doesn't seem to work, check with SoftHack007
+  delay(500);
+  // un-comment the next lines for redirecting kernel error messages to Serial
+  // #if ARDUINO_USB_CDC_ON_BOOT
+  // Serial0.setDebugOutput(false);
+  // #endif
+  // Serial.setDebugOutput(true);
+
+  // softhack007: USB CDC needs a bit more time to initialize
+#if ARDUINO_USB_CDC_ON_BOOT || ARDUINO_USB_MODE
+  unsigned waitCounter = 0;
+  do {
+    delay(1000);
+    waitCounter ++;
+  } while ((!Serial) && (waitCounter < 8));  // wait until Serial is ready / connected
+  delay(3000); // this extra delay avoids repeating disconnects on -s2 "Disconnected (ClearCommError failed"
+  Serial.println("   **** COMMODORE BASIC V2 ****   ");
+#endif
+  Serial.println("Ready.\n");
+  if (Serial) Serial.flush(); // drain output buffer
 
   // print("%s %s %s\n",__PRETTY_FUNCTION__,name, success?"success":"failed");
 };

--- a/src/SysModule.h
+++ b/src/SysModule.h
@@ -11,12 +11,16 @@
 
 #pragma once
 #include <Arduino.h>
+#include <HardwareSerial.h>  // ensure we have the correct "Serial" on new MCUs (depends on ARDUINO_USB_MODE and ARDUINO_USB_CDC_ON_BOOT)
+#include <WiFi.h>
+#include "esp_wifi.h"
+#include <LittleFS.h>        // make sure that ArduinoJson knows we have LittleFS
 
 // #define ARDUINOJSON_ENABLE_ARDUINO_STRING 0
 #include "ArduinoJson.h"
 
-#define uint8Max 255U
-#define uint16Max 65535U
+#define uint8Max UINT8_MAX
+#define uint16Max UINT16_MAX
 
 class SysModule {
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,9 @@
 
 //setup all modules
 void setup() {
+  // pinMode(LED_BUILTIN, OUTPUT);
+  // digitalWrite(LED_BUILTIN, HIGH);
+
   mdls = new SysModules();
   
   print = new SysModPrint();
@@ -81,7 +84,7 @@ void setup() {
     wledAudioMod = new UserModWLEDAudio();
   #endif
 
-  //prefered default order in the UI. 
+  //preferred default order in the UI. 
   //Reorder with care! If changed make sure mdlEnabled.chFun executes var.createNestedArray("value"); and saveModel! 
   //Default: add below, not in between
   #ifdef APPMOD_LEDS
@@ -119,9 +122,15 @@ void setup() {
 
   //do not add mdls itself as it does setup and loop for itself!!! (it is the orchestrator)
   mdls->setup();
+
+  // digitalWrite(LED_BUILTIN, LOW);
 }
 
 //loop all modules
 void loop() {
   mdls->loop();
+
+  // static bool onoff = false;
+  // onoff = !onoff;
+  // digitalWrite(LED_BUILTIN, onoff? HIGH:LOW);
 }


### PR DESCRIPTION
* tweaks for serial initialisation
* minor additions to platformio.ini:
  - fix the platform version. This is needed, otherwise pio will use a random version (actually the last one downloaded)
  - S2: USB CDC flags added
  - LFS_THREADSAFE added
* FastLED optional flags (comments)
* include HardwareSerial.h
