### PR TITLE
Esp32 s2 patch2 - debug improvement, and starting to collect some esp32 tools

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -11,6 +11,8 @@
 ;; framework = arduino
 ;; monitor_speed = 115200
 ;; upload_speed = 115200
+;; build_type = debug
+;; build_type = release
 
 [starmod]
 lib_deps =
@@ -79,20 +81,24 @@ lib_deps =
 
 [env:lolin_s2_mini]
 board = lolin_s2_mini ;https://github.com/platformio/platform-espressif32/blob/develop/boards/lolin_s2_mini.json
-platform = espressif32@5.3.0
+;; platform = espressif32@5.3.0 ;; WLED default framework version
+platform = espressif32@6.3.0    ;; this one behaves better for debugging
 framework = arduino
 upload_speed = 256000
 monitor_speed = 115200
 board_build.partitions = tools/WLED_ESP32_4MB_256KB_FS.csv   ;; 1.8MB firmware, 256KB filesystem (esptool erase_flash needed when changing from "standard WLED" partitions)
 monitor_filters = esp32_exception_decoder
 board_build.filesystem = littlefs
+build_unflags =
+  ; -DARDUINO_USB_CDC_ON_BOOT=1 ;; un-comment if you want to use a "real" serial-to-USB moddule
 build_flags =
   -DCONFIG_IDF_TARGET_ESP32S2=1
   -DCONFIG_ASYNC_TCP_USE_WDT=0
   -DLFS_THREADSAFE            ;; enables use of semaphores in LittleFS driver
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; for debugging over USB
-  ; -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; without USB debug (use in case your board hangs without USB connection)
+  ; -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; with serial-to-USB moddule (use in case your board hangs without USB connection)
   -DARDUINO_USB_MODE=0        ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (mandatory on -S2)
+  ; -D DEBUG=1 -D CORE_DEBUG_LEVEL=1 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
   ${appmod_leds.build_flags}
   ${usermod_e131.build_flags}
   ; ${usermod_ha.build_flags}

--- a/src/Sys/SysModPrint.cpp
+++ b/src/Sys/SysModPrint.cpp
@@ -14,6 +14,7 @@
 #include "SysModUI.h"
 #include "SysModModel.h"
 #include "SysModWeb.h"
+#include "esp32Tools.h"
 
 SysModPrint::SysModPrint() :SysModule("Print") {
   // print("%s %s\n", __PRETTY_FUNCTION__, name);
@@ -42,6 +43,11 @@ SysModPrint::SysModPrint() :SysModule("Print") {
   delay(3000); // this extra delay avoids repeating disconnects on -s2 "Disconnected (ClearCommError failed"
   Serial.println("   **** COMMODORE BASIC V2 ****   ");
 #endif
+  if (!sysTools_normal_startup() && Serial) { // only print if Serial is connected, and startup was not normal
+    Serial.print("\nWARNING - possible crash: ");
+    Serial.println(sysTools_getRestartReason());
+    Serial.println("");
+  }
   Serial.println("Ready.\n");
   if (Serial) Serial.flush(); // drain output buffer
 

--- a/src/Sys/SysModPrint.cpp
+++ b/src/Sys/SysModPrint.cpp
@@ -18,13 +18,19 @@
 SysModPrint::SysModPrint() :SysModule("Print") {
   // print("%s %s\n", __PRETTY_FUNCTION__, name);
 
+#if ARDUINO_USB_CDC_ON_BOOT || !defined(CONFIG_IDF_TARGET_ESP32S2)
   Serial.begin(115200);
+#else
+  Serial.begin(115200, SERIAL_8N1, RX, TX);   // workaround for Lolin S2 mini - this board uses non-standard pins for RX and TX
+#endif
   delay(500);
   // un-comment the next lines for redirecting kernel error messages to Serial
-  // #if ARDUINO_USB_CDC_ON_BOOT
-  // Serial0.setDebugOutput(false);
-  // #endif
-  // Serial.setDebugOutput(true);
+  #if CORE_DEBUG_LEVEL
+  #if ARDUINO_USB_CDC_ON_BOOT
+  Serial0.setDebugOutput(false);
+  #endif
+  Serial.setDebugOutput(true);
+  #endif
 
   // softhack007: USB CDC needs a bit more time to initialize
 #if ARDUINO_USB_CDC_ON_BOOT || ARDUINO_USB_MODE

--- a/src/Sys/SysModSystem.cpp
+++ b/src/Sys/SysModSystem.cpp
@@ -14,6 +14,7 @@
 #include "SysModUI.h"
 #include "SysModWeb.h"
 #include "SysModModel.h"
+#include "esp32Tools.h"
 
 // #include <Esp.h>
 #include <rom/rtc.h>
@@ -140,36 +141,44 @@ void SysModSystem::loop10s() {
 
 //replace code by sentence as soon it occurs, so we know what will happen and what not
 void SysModSystem::addResetReasonsSelect(JsonArray select) {
-  select.add("NO_MEAN"); // 0,
-  select.add("Vbat power on reset");//POWERON_RESET"); // 1,    /**<1, */
-  select.add("SW_RESET (2)"); // 2,    /**<3, Software reset digital core*/
-  select.add("SW_RESET (3)"); // 3,    /**<3, Software reset digital core*/
-  select.add("OWDT_RESET"); // 4,    /**<4, Legacy watch dog reset digital core*/
-  select.add("DEEPSLEEP_RESET"); // 5,    /**<3, Deep Sleep reset digital core*/
-  select.add("SDIO_RESET"); // 6,    /**<6, Reset by SLC module, reset digital core*/
-  select.add("TG0WDT_SYS_RESET"); // 7,    /**<7, Timer Group0 Watch dog reset digital core*/
-  select.add("TG1WDT_SYS_RESET"); // 8,    /**<8, Timer Group1 Watch dog reset digital core*/
-  select.add("RTCWDT_SYS_RESET"); // 9,    /**<9, RTC Watch dog Reset digital core*/
-  select.add("INTRUSION_RESET"); //10,    /**<10, Instrusion tested to reset CPU*/
-  select.add("TGWDT_CPU_RESET"); //11,    /**<11, Time Group reset CPU*/
-  select.add("SW reset CPU (12)");//SW_CPU_RESET"); //12,    /**<12, */
-  select.add("RTCWDT_CPU_RESET"); //13,    /**<13, RTC Watch dog Reset CPU*/
-  select.add("for APP CPU, reset by PRO CPU");//EXT_CPU_RESET"); //14,    /**<14, */
-  select.add("RTCWDT_BROWN_OUT_RESET"); //15,    /**<15, Reset when the vdd voltage is not stable*/
-  select.add("RTCWDT_RTC_RESET"); //16     /**<16, RTC Watch dog reset digital core and rtc module*/
+  select.add(String("NO_MEAN (0)")); // 0,
+  select.add(sysTools_reset2String( 1)); //POWERON_RESET"); // 1,    /**<1, */
+  select.add(sysTools_reset2String( 2)); // 2,    /**<3, Software reset digital core*/
+  select.add(sysTools_reset2String( 3)); // 3,    /**<3, Software reset digital core*/
+  select.add(sysTools_reset2String( 4)); // 4,    /**<4, Legacy watch dog reset digital core*/
+  select.add(sysTools_reset2String( 5)); // 5,    /**<3, Deep Sleep reset digital core*/
+  select.add(sysTools_reset2String( 6)); // 6,    /**<6, Reset by SLC module, reset digital core*/
+  select.add(sysTools_reset2String( 7)); // 7,    /**<7, Timer Group0 Watch dog reset digital core*/
+  select.add(sysTools_reset2String( 8)); // 8,    /**<8, Timer Group1 Watch dog reset digital core*/
+  select.add(sysTools_reset2String( 9)); // 9,    /**<9, RTC Watch dog Reset digital core*/
+  select.add(sysTools_reset2String(10)); //10,    /**<10, Instrusion tested to reset CPU*/
+  select.add(sysTools_reset2String(11)); //11,    /**<11, Time Group reset CPU*/
+  select.add(sysTools_reset2String(12)); //SW_CPU_RESET"); //12,    /**<12, */
+  select.add(sysTools_reset2String(13)); //13,    /**<13, RTC Watch dog Reset CPU*/
+  select.add(sysTools_reset2String(14)); //EXT_CPU_RESET"); //14,    /**<14, */
+  select.add(sysTools_reset2String(15)); //15,    /**<15, Reset when the vdd voltage is not stable*/
+  select.add(sysTools_reset2String(16)); //16     /**<16, RTC Watch dog reset digital core and rtc module*/
+  // codes below are only used on -S3/-S2/-C3
+  select.add(sysTools_reset2String(17)); //17     /* Time Group1 reset CPU */
+  select.add(sysTools_reset2String(18)); //18     /* super watchdog reset digital core and rtc module */
+  select.add(sysTools_reset2String(19)); //19     /* glitch reset digital core and rtc module */
+  select.add(sysTools_reset2String(20)); //20     /* efuse reset digital core */
+  select.add(sysTools_reset2String(21)); //21     /* usb uart reset digital core */
+  select.add(sysTools_reset2String(22)); //22     /* usb jtag reset digital core */
+  select.add(sysTools_reset2String(23)); //23     /* power glitch reset digital core and rtc module */
 }
 
 //replace code by sentence as soon it occurs, so we know what will happen and what not
 void SysModSystem::addRestartReasonsSelect(JsonArray select) {
-  select.add("ESP_RST_UNKNOWN");//  //!< Reset reason can not be determined
-  select.add("Reset due to power-on event");//ESP_RST_POWERON");//  //!< 
-  select.add("ESP_RST_EXT");//      //!< Reset by external pin (not applicable for ESP32)
-  select.add("Software reset via esp_restart (3)");//ESP_RST_SW");//       //!< Software reset via esp_restart
-  select.add("SW reset due to exception/panic (4)");//ESP_RST_PANIC");//    //!< 
-  select.add("ESP_RST_INT_WDT");//  //!< Reset (software or hardware) due to interrupt watchdog
-  select.add("ESP_RST_TASK_WDT");// //!< Reset due to task watchdog
-  select.add("ESP_RST_WDT");//      //!< Reset due to other watchdogs
-  select.add("ESP_RST_DEEPSLEEP");////!< Reset after exiting deep sleep mode
-  select.add("ESP_RST_BROWNOUT");// //!< Brownout reset (software or hardware)
-  select.add("ESP_RST_SDIO");//     //!< Reset over SDIO
+  select.add(String("(0) ESP_RST_UNKNOWN"));//           //!< Reset reason can not be determined
+  select.add(sysTools_restart2String( 1)); // ESP_RST_POWERON");//  //!< 
+  select.add(sysTools_restart2String( 2)); // !< Reset by external pin (not applicable for ESP32)
+  select.add(sysTools_restart2String( 3)); // ESP_RST_SW");//       //!< Software reset via esp_restart
+  select.add(sysTools_restart2String( 4)); //ESP_RST_PANIC");//    //!< 
+  select.add(sysTools_restart2String( 5)); //  //!< Reset (software or hardware) due to interrupt watchdog
+  select.add(sysTools_restart2String( 6)); // //!< Reset due to task watchdog
+  select.add(sysTools_restart2String( 7)); //      //!< Reset due to other watchdogs
+  select.add(sysTools_restart2String( 8)); ////!< Reset after exiting deep sleep mode
+  select.add(sysTools_restart2String( 9)); // //!< Brownout reset (software or hardware)
+  select.add(sysTools_restart2String(10)); //     //!< Reset over SDIO
 }

--- a/src/Sys/esp32Tools.cpp
+++ b/src/Sys/esp32Tools.cpp
@@ -65,9 +65,19 @@ String sysTools_getRestartReason() {
   longText = longText + ".";
   return longText;
 }
-	
 
+// helper for SysModSystem::addRestartReasonsSelect. Returns "(#) ReasonText"
+String sysTools_restart2String(int reasoncode) {
+  esp_reset_reason_t restartCode = esp_reset_reason_t(reasoncode); // its a trick, not a sony ;-)
+  String longText = String("(") + String(reasoncode) + String( ") ") + restartCode2Info(restartCode);
+  return longText;
+}
 
+// helper for SysModSystem::addResetReasonsSelect. Returns "CoreResetReasonText (#)"
+String sysTools_reset2String(int resetCode) {
+  String longText = resetCode2Info(resetCode) + String(" (") + String(resetCode) + String(")");
+  return longText;
+}
 
 
 // stack debug tools - find loopTask task, and queries it's free stack size
@@ -191,7 +201,7 @@ static String restartCode2Info(esp_reset_reason_t reason) {
       case ESP_RST_POWERON:  return("power-on event"); break;
       case ESP_RST_EXT:      return("external pin reset"); break;
       case ESP_RST_SW:       return("SW restart by esp_restart()"); break;
-      case ESP_RST_PANIC:    return("SW error (panic or exception)"); break;
+      case ESP_RST_PANIC:    return("SW error - panic or exception"); break;
       case ESP_RST_INT_WDT:  return("interrupt watchdog"); break;
       case ESP_RST_TASK_WDT: return("task watchdog"); break;
       case ESP_RST_WDT:      return("other watchdog"); break;

--- a/src/Sys/esp32Tools.cpp
+++ b/src/Sys/esp32Tools.cpp
@@ -1,0 +1,250 @@
+/*
+   @title     StarMod
+   @file      esp32Tools.cpp
+   @date      20240121
+   @repo      https://github.com/ewowi/StarMod
+   @Authors   https://github.com/ewowi/StarMod/commits/main
+   @Copyright (c) 2024 Github StarMod Commit Authors
+   @license   GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+   @license   For non GPL-v3 usage, commercial licenses must be purchased. Contact moonmodules@icloud.com
+*/
+
+// This is a collection of ESP32 specific low-level functions.
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include <Arduino.h>
+#include "esp32Tools.h"
+
+#include "soc/soc.h"
+#include "soc/rtc_cntl_reg.h"
+
+#include <Esp.h>
+// get the right RTC.H for each MCU
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 0, 0)
+#if CONFIG_IDF_TARGET_ESP32S2
+#include <esp32s2/rom/rtc.h>
+#elif CONFIG_IDF_TARGET_ESP32C3
+#include <esp32c3/rom/rtc.h>
+#elif CONFIG_IDF_TARGET_ESP32S3
+#include <esp32s3/rom/rtc.h>
+#elif CONFIG_IDF_TARGET_ESP32 // ESP32/PICO-D4
+#include <esp32/rom/rtc.h>
+#endif
+#else // ESP32 Before IDF 4.0
+#include <rom/rtc.h>
+#endif
+
+// forward declarations of local helper functions
+static esp_reset_reason_t getRestartReason();
+static int getCoreResetReason(int core);
+static String resetCode2Info(int reason);
+static String restartCode2InfoLong(esp_reset_reason_t reason);
+static String restartCode2Info(esp_reset_reason_t reason);
+
+
+// check if estart was "normal"
+bool sysTools_normal_startup() {
+	esp_reset_reason_t restartCode = getRestartReason();
+	if ((restartCode == ESP_RST_POWERON) || (restartCode == ESP_RST_SW)) return true;  // poweron or esp_restart()
+	return false;
+}
+
+// RESTART reason as long string
+String sysTools_getRestartReason() {
+  esp_reset_reason_t restartCode = getRestartReason();
+	String reasonText = restartCode2InfoLong(restartCode);
+	String longText = String("(code ") + String((int)restartCode) + String( ") ") + reasonText;
+
+  int core0code = getCoreResetReason(0);
+  int core1code = getCoreResetReason(1);
+  longText = longText + ". Core#0 (code " + String(core0code) + ") " + resetCode2Info(core0code);
+  if (core1code > 0) 
+    longText = longText + "; Core#1 (code " + String(core1code) + ") " + resetCode2Info(core1code);
+
+  longText = longText + ".";
+  return longText;
+}
+	
+
+
+
+
+// stack debug tools - find loopTask task, and queries it's free stack size
+
+#if INCLUDE_xTaskGetHandle   // only supported on newer frameworks
+int sysTools_get_arduino_maxStackUsage(void) {
+  static TaskHandle_t loop_taskHandle = NULL;                   // to store the task handle for later calls
+  char * loop_taskname = pcTaskGetTaskName(loop_taskHandle);    // ask for name of the known task (to make sure we are still looking at the right one)
+
+  if ((loop_taskHandle == NULL) || (loop_taskname == NULL) || (strncmp(loop_taskname, "loopTask", 8) != 0)) {
+    loop_taskHandle = xTaskGetHandle("loopTask");              // need to look for the task by name. FreeRTOS docs say this is very slow, so we store the result for next time
+  }
+
+  if (loop_taskHandle != NULL) return uxTaskGetStackHighWaterMark(loop_taskHandle); // got it !!
+  else return -1;
+}
+
+int sysTools_get_webserver_maxStackUsage(void) {
+  static TaskHandle_t tcp_taskHandle = NULL;                   // to store the task handle for later calls
+  char * tcp_taskname = pcTaskGetTaskName(tcp_taskHandle);     // ask for name of the known task (to make sure we are still looking at the right one)
+
+  if ((tcp_taskHandle == NULL) || (tcp_taskname == NULL) || (strncmp(tcp_taskname, "async_tcp", 9) != 0)) {
+    tcp_taskHandle = xTaskGetHandle("async_tcp");              // need to look for the task by name. FreeRTOS docs say this is very slow, so we store the result for next time
+  }
+
+  if (tcp_taskHandle != NULL) return uxTaskGetStackHighWaterMark(tcp_taskHandle); // got it !!
+  else return -1;
+}
+#else
+#warning cannot query task stacksize on your system
+int sysTools_get_arduino_maxStackUsage(void) { return -1;}
+int sysTools_get_webserver_maxStackUsage(void)  { return -1;}
+#endif
+
+
+// helper fuctions
+static int getCoreResetReason(int core) {
+  if (core >= ESP.getChipCores()) return 0;
+  return((int)rtc_get_reset_reason(core));
+}
+
+static String resetCode2Info(int reason) {
+  switch(reason) {
+
+    case 1 : //  1 =  Vbat power on reset
+      return F("power-on"); break;
+    case 2 : // 2 = this code is not defined on ESP32
+      return F("exception"); break;
+    case 3 : // 3 = Software reset digital core
+       return F("SW reset"); break;
+    case 12: //12 = Software reset CPU
+       return F("SW restart"); break;
+    case 5 : // 5 = Deep Sleep wakeup reset digital core
+       return F("wakeup"); break;
+    case 14:  //14 = for APP CPU, reset by PRO CPU
+      return F("restart"); break;
+    case 15: //15 = Reset when the vdd voltage is not stable (brownout)
+      return F("brown-out"); break;
+
+    // watchdog resets
+    case 4 : // 4 = Legacy watch dog reset digital core
+    case 6 : // 6 = Reset by SLC module, reset digital core
+    case 7 : // 7 = Timer Group0 Watch dog reset digital core
+    case 8 : // 8 = Timer Group1 Watch dog reset digital core
+    case 9 : // 9 = RTC Watch dog Reset digital core
+    case 11: //11 = Time Group watchdog reset CPU
+    case 13: //13 = RTC Watch dog Reset CPU
+    case 16: //16 = RTC Watch dog reset digital core and rtc module
+    case 17: //17 = Time Group1 reset CPU
+      return F("watchdog"); break;
+    case 18: //18 = super watchdog reset digital core and rtc module
+      return F("super watchdog"); break;
+
+    // misc
+    case 10: // 10 = Instrusion tested to reset CPU
+      return F("intrusion"); break;
+    case 19: //19 = glitch reset digital core and rtc module
+      return F("glitch"); break;
+    case 20: //20 = efuse reset digital core
+      return F("EFUSE reset"); break;
+    case 21: //21 = usb uart reset digital core
+      return F("USB UART reset"); break;
+    case 22: //22 = usb jtag reset digital core
+     return F("JTAG reset"); break;
+    case 23: //23 = power glitch reset digital core and rtc module
+      return F("power glitch"); break;
+
+    // unknown reason code
+    case 0:
+      return F(""); break;
+    default: 
+      return F("unknown"); break;
+  }
+}
+
+
+static esp_reset_reason_t getRestartReason() {
+  return(esp_reset_reason());
+}
+
+static String restartCode2InfoLong(esp_reset_reason_t reason) {
+    switch (reason) {
+      case ESP_RST_UNKNOWN:  return(F("Reset reason can not be determined")); break;
+      case ESP_RST_POWERON:  return(F("Restart due to power-on event")); break;
+      case ESP_RST_EXT:      return(F("Reset by external pin (not applicable for ESP32)")); break;
+      case ESP_RST_SW:       return(F("Software restart via esp_restart()")); break;
+      case ESP_RST_PANIC:    return(F("Software reset due to panic or unhandled exception (SW error)")); break;
+      case ESP_RST_INT_WDT:  return(F("Reset (software or hardware) due to interrupt watchdog")); break;
+      case ESP_RST_TASK_WDT: return(F("Reset due to task watchdog")); break;
+      case ESP_RST_WDT:      return(F("Reset due to other watchdogs")); break;
+      case ESP_RST_DEEPSLEEP:return(F("Restart after exiting deep sleep mode")); break;
+      case ESP_RST_BROWNOUT: return(F("Brownout Reset (software or hardware)")); break;
+      case ESP_RST_SDIO:     return(F("Reset over SDIO")); break;
+    }
+  return(F("unknown"));
+}
+
+static String restartCode2Info(esp_reset_reason_t reason) {
+    switch (reason) {
+      case ESP_RST_UNKNOWN:  return(F("unknown reason")); break;
+      case ESP_RST_POWERON:  return(F("power-on event")); break;
+      case ESP_RST_EXT:      return(F("external pin reset")); break;
+      case ESP_RST_SW:       return(F("SW restart by esp_restart()")); break;
+      case ESP_RST_PANIC:    return(F("SW error (panic or exception)")); break;
+      case ESP_RST_INT_WDT:  return(F("interrupt watchdog")); break;
+      case ESP_RST_TASK_WDT: return(F("task watchdog")); break;
+      case ESP_RST_WDT:      return(F("other watchdog")); break;
+      case ESP_RST_DEEPSLEEP:return(F("exit from deep sleep")); break;
+      case ESP_RST_BROWNOUT: return(F("Brownout Reset")); break;
+      case ESP_RST_SDIO:     return(F("Reset over SDIO")); break;
+    }
+  return(F("unknown"));
+}
+
+
+// from WLEDMM - will integrate this later
+#if 0
+  DEBUG_PRINT(F("esp32 "));
+  DEBUG_PRINTLN(ESP.getSdkVersion());
+  #if defined(ESP_ARDUINO_VERSION)
+    DEBUG_PRINTF("arduino-esp32 v%d.%d.%d\n", int(ESP_ARDUINO_VERSION_MAJOR), int(ESP_ARDUINO_VERSION_MINOR), int(ESP_ARDUINO_VERSION_PATCH));  // availeable since v2.0.0
+  #else
+    DEBUG_PRINTLN(F("arduino-esp32 v1.0.x\n"));  // we can't say in more detail.
+  #endif
+
+  USER_PRINT(F("CPU:   ")); USER_PRINT(ESP.getChipModel());
+  USER_PRINT(F(" rev.")); USER_PRINT(ESP.getChipRevision());
+  USER_PRINT(F(", ")); USER_PRINT(ESP.getChipCores()); USER_PRINT(F(" core(s)"));
+  USER_PRINT(F(", ")); USER_PRINT(ESP.getCpuFreqMHz()); USER_PRINTLN(F("MHz."));
+
+  USER_PRINT(F("CPU    "));
+  esp_reset_reason_t resetReason = getRestartReason();
+  USER_PRINT(restartCode2InfoLong(resetReason));
+  USER_PRINT(F(" (code "));
+  USER_PRINT((int)resetReason);
+  USER_PRINT(F("). "));
+  int core0code = getCoreResetReason(0);
+  int core1code = getCoreResetReason(1);
+  USER_PRINTF("Core#0 %s (%d)", resetCode2Info(core0code).c_str(), core0code);
+  if (core1code > 0) {USER_PRINTF("; Core#1 %s (%d)", resetCode2Info(core1code).c_str(), core1code);}
+  USER_PRINTLN(F("."));
+
+  USER_PRINT(F("FLASH: ")); USER_PRINT((ESP.getFlashChipSize()/1024)/1024);
+  USER_PRINT(F("MB, Mode ")); USER_PRINT(ESP.getFlashChipMode());
+  switch (ESP.getFlashChipMode()) {
+    // missing: Octal modes
+    case FM_QIO:  DEBUG_PRINT(F(" (QIO)")); break;
+    case FM_QOUT: DEBUG_PRINT(F(" (QOUT)"));break;
+    case FM_DIO:  DEBUG_PRINT(F(" (DIO)")); break;
+    case FM_DOUT: DEBUG_PRINT(F(" (DOUT)"));break;
+    default: break;
+  }
+  USER_PRINT(F(", speed ")); USER_PRINT(ESP.getFlashChipSpeed()/1000000);USER_PRINTLN(F("MHz."));  
+#endif
+
+
+
+#else
+	#error SystemTools are not yet availeable for your environment
+#endif

--- a/src/Sys/esp32Tools.cpp
+++ b/src/Sys/esp32Tools.cpp
@@ -113,19 +113,19 @@ static String resetCode2Info(int reason) {
   switch(reason) {
 
     case 1 : //  1 =  Vbat power on reset
-      return F("power-on"); break;
+      return "power-on"; break;
     case 2 : // 2 = this code is not defined on ESP32
-      return F("exception"); break;
+      return "exception"; break;
     case 3 : // 3 = Software reset digital core
-       return F("SW reset"); break;
+       return "SW reset"; break;
     case 12: //12 = Software reset CPU
-       return F("SW restart"); break;
+       return "SW restart"; break;
     case 5 : // 5 = Deep Sleep wakeup reset digital core
-       return F("wakeup"); break;
+       return "wakeup"; break;
     case 14:  //14 = for APP CPU, reset by PRO CPU
-      return F("restart"); break;
+      return "restart"; break;
     case 15: //15 = Reset when the vdd voltage is not stable (brownout)
-      return F("brown-out"); break;
+      return "brown-out"; break;
 
     // watchdog resets
     case 4 : // 4 = Legacy watch dog reset digital core
@@ -137,29 +137,29 @@ static String resetCode2Info(int reason) {
     case 13: //13 = RTC Watch dog Reset CPU
     case 16: //16 = RTC Watch dog reset digital core and rtc module
     case 17: //17 = Time Group1 reset CPU
-      return F("watchdog"); break;
+      return "watchdog"; break;
     case 18: //18 = super watchdog reset digital core and rtc module
-      return F("super watchdog"); break;
+      return "super watchdog"; break;
 
     // misc
     case 10: // 10 = Instrusion tested to reset CPU
-      return F("intrusion"); break;
+      return "intrusion"; break;
     case 19: //19 = glitch reset digital core and rtc module
-      return F("glitch"); break;
+      return "glitch"; break;
     case 20: //20 = efuse reset digital core
-      return F("EFUSE reset"); break;
+      return "EFUSE reset"; break;
     case 21: //21 = usb uart reset digital core
-      return F("USB UART reset"); break;
+      return "USB UART reset"; break;
     case 22: //22 = usb jtag reset digital core
-     return F("JTAG reset"); break;
+     return "JTAG reset"; break;
     case 23: //23 = power glitch reset digital core and rtc module
-      return F("power glitch"); break;
+      return "power glitch"; break;
 
     // unknown reason code
     case 0:
-      return F(""); break;
+      return "none"; break;
     default: 
-      return F("unknown"); break;
+      return "unknown"; break;
   }
 }
 
@@ -170,77 +170,77 @@ static esp_reset_reason_t getRestartReason() {
 
 static String restartCode2InfoLong(esp_reset_reason_t reason) {
     switch (reason) {
-      case ESP_RST_UNKNOWN:  return(F("Reset reason can not be determined")); break;
-      case ESP_RST_POWERON:  return(F("Restart due to power-on event")); break;
-      case ESP_RST_EXT:      return(F("Reset by external pin (not applicable for ESP32)")); break;
-      case ESP_RST_SW:       return(F("Software restart via esp_restart()")); break;
-      case ESP_RST_PANIC:    return(F("Software reset due to panic or unhandled exception (SW error)")); break;
-      case ESP_RST_INT_WDT:  return(F("Reset (software or hardware) due to interrupt watchdog")); break;
-      case ESP_RST_TASK_WDT: return(F("Reset due to task watchdog")); break;
-      case ESP_RST_WDT:      return(F("Reset due to other watchdogs")); break;
-      case ESP_RST_DEEPSLEEP:return(F("Restart after exiting deep sleep mode")); break;
-      case ESP_RST_BROWNOUT: return(F("Brownout Reset (software or hardware)")); break;
-      case ESP_RST_SDIO:     return(F("Reset over SDIO")); break;
+      case ESP_RST_UNKNOWN:  return("Reset reason can not be determined"); break;
+      case ESP_RST_POWERON:  return("Restart due to power-on event"); break;
+      case ESP_RST_EXT:      return("Reset by external pin (not applicable for ESP32)"); break;
+      case ESP_RST_SW:       return("Software restart via esp_restart()"); break;
+      case ESP_RST_PANIC:    return("Software reset due to panic or unhandled exception (SW error)"); break;
+      case ESP_RST_INT_WDT:  return("Reset (software or hardware) due to interrupt watchdog"); break;
+      case ESP_RST_TASK_WDT: return("Reset due to task watchdog"); break;
+      case ESP_RST_WDT:      return("Reset due to other watchdogs"); break;
+      case ESP_RST_DEEPSLEEP:return("Restart after exiting deep sleep mode"); break;
+      case ESP_RST_BROWNOUT: return("Brownout Reset (software or hardware)"); break;
+      case ESP_RST_SDIO:     return("Reset over SDIO"); break;
     }
-  return(F("unknown"));
+  return("unknown");
 }
 
 static String restartCode2Info(esp_reset_reason_t reason) {
     switch (reason) {
-      case ESP_RST_UNKNOWN:  return(F("unknown reason")); break;
-      case ESP_RST_POWERON:  return(F("power-on event")); break;
-      case ESP_RST_EXT:      return(F("external pin reset")); break;
-      case ESP_RST_SW:       return(F("SW restart by esp_restart()")); break;
-      case ESP_RST_PANIC:    return(F("SW error (panic or exception)")); break;
-      case ESP_RST_INT_WDT:  return(F("interrupt watchdog")); break;
-      case ESP_RST_TASK_WDT: return(F("task watchdog")); break;
-      case ESP_RST_WDT:      return(F("other watchdog")); break;
-      case ESP_RST_DEEPSLEEP:return(F("exit from deep sleep")); break;
-      case ESP_RST_BROWNOUT: return(F("Brownout Reset")); break;
-      case ESP_RST_SDIO:     return(F("Reset over SDIO")); break;
+      case ESP_RST_UNKNOWN:  return("unknown reason"); break;
+      case ESP_RST_POWERON:  return("power-on event"); break;
+      case ESP_RST_EXT:      return("external pin reset"); break;
+      case ESP_RST_SW:       return("SW restart by esp_restart()"); break;
+      case ESP_RST_PANIC:    return("SW error (panic or exception)"); break;
+      case ESP_RST_INT_WDT:  return("interrupt watchdog"); break;
+      case ESP_RST_TASK_WDT: return("task watchdog"); break;
+      case ESP_RST_WDT:      return("other watchdog"); break;
+      case ESP_RST_DEEPSLEEP:return("exit from deep sleep"); break;
+      case ESP_RST_BROWNOUT: return("Brownout Reset"); break;
+      case ESP_RST_SDIO:     return("Reset over SDIO"); break;
     }
-  return(F("unknown"));
+  return("unknown");
 }
 
 
 // from WLEDMM - will integrate this later
 #if 0
-  DEBUG_PRINT(F("esp32 "));
+  DEBUG_PRINT("esp32 ");
   DEBUG_PRINTLN(ESP.getSdkVersion());
   #if defined(ESP_ARDUINO_VERSION)
-    DEBUG_PRINTF("arduino-esp32 v%d.%d.%d\n", int(ESP_ARDUINO_VERSION_MAJOR), int(ESP_ARDUINO_VERSION_MINOR), int(ESP_ARDUINO_VERSION_PATCH));  // availeable since v2.0.0
+    DEBUG_PRINT"arduino-esp32 v%d.%d.%d\n", int(ESP_ARDUINO_VERSION_MAJOR), int(ESP_ARDUINO_VERSION_MINOR), int(ESP_ARDUINO_VERSION_PATCH));  // availeable since v2.0.0
   #else
-    DEBUG_PRINTLN(F("arduino-esp32 v1.0.x\n"));  // we can't say in more detail.
+    DEBUG_PRINTLN("arduino-esp32 v1.0.x\n");  // we can't say in more detail.
   #endif
 
-  USER_PRINT(F("CPU:   ")); USER_PRINT(ESP.getChipModel());
-  USER_PRINT(F(" rev.")); USER_PRINT(ESP.getChipRevision());
-  USER_PRINT(F(", ")); USER_PRINT(ESP.getChipCores()); USER_PRINT(F(" core(s)"));
-  USER_PRINT(F(", ")); USER_PRINT(ESP.getCpuFreqMHz()); USER_PRINTLN(F("MHz."));
+  USER_PRINT("CPU:   "); USER_PRINT(ESP.getChipModel());
+  USER_PRINT(" rev."); USER_PRINT(ESP.getChipRevision());
+  USER_PRINT(", "); USER_PRINT(ESP.getChipCores()); USER_PRINT(" core(s)");
+  USER_PRINT(", "); USER_PRINT(ESP.getCpuFreqMHz()); USER_PRINTLN("MHz.");
 
-  USER_PRINT(F("CPU    "));
+  USER_PRINT("CPU    ");
   esp_reset_reason_t resetReason = getRestartReason();
   USER_PRINT(restartCode2InfoLong(resetReason));
-  USER_PRINT(F(" (code "));
+  USER_PRINT(" (code ");
   USER_PRINT((int)resetReason);
-  USER_PRINT(F("). "));
+  USER_PRINT(". ");
   int core0code = getCoreResetReason(0);
   int core1code = getCoreResetReason(1);
-  USER_PRINTF("Core#0 %s (%d)", resetCode2Info(core0code).c_str(), core0code);
-  if (core1code > 0) {USER_PRINTF("; Core#1 %s (%d)", resetCode2Info(core1code).c_str(), core1code);}
-  USER_PRINTLN(F("."));
+  USER_PRINT"Core#0 %s (%d)", resetCode2Info(core0code).c_str(), core0code);
+  if (core1code > 0) {USER_PRINT"; Core#1 %s (%d)", resetCode2Info(core1code).c_str(), core1code);}
+  USER_PRINTLN(".");
 
-  USER_PRINT(F("FLASH: ")); USER_PRINT((ESP.getFlashChipSize()/1024)/1024);
-  USER_PRINT(F("MB, Mode ")); USER_PRINT(ESP.getFlashChipMode());
+  USER_PRINT("FLASH: "); USER_PRINT((ESP.getFlashChipSize()/1024)/1024);
+  USER_PRINT("MB, Mode "); USER_PRINT(ESP.getFlashChipMode());
   switch (ESP.getFlashChipMode()) {
     // missing: Octal modes
-    case FM_QIO:  DEBUG_PRINT(F(" (QIO)")); break;
-    case FM_QOUT: DEBUG_PRINT(F(" (QOUT)"));break;
-    case FM_DIO:  DEBUG_PRINT(F(" (DIO)")); break;
-    case FM_DOUT: DEBUG_PRINT(F(" (DOUT)"));break;
+    case FM_QIO:  DEBUG_PRINT(" (QIO)"); break;
+    case FM_QOUT: DEBUG_PRINT(" (QOUT)");break;
+    case FM_DIO:  DEBUG_PRINT(" (DIO)"); break;
+    case FM_DOUT: DEBUG_PRINT(" (DOUT)");break;
     default: break;
   }
-  USER_PRINT(F(", speed ")); USER_PRINT(ESP.getFlashChipSpeed()/1000000);USER_PRINTLN(F("MHz."));  
+  USER_PRINT(", speed "); USER_PRINT(ESP.getFlashChipSpeed()/1000000);USER_PRINTLN("MHz.");  
 #endif
 
 

--- a/src/Sys/esp32Tools.h
+++ b/src/Sys/esp32Tools.h
@@ -1,0 +1,18 @@
+/*
+   @title     StarMod
+   @file      esp32Tools.h
+   @date      20240121
+   @repo      https://github.com/ewowi/StarMod
+   @Authors   https://github.com/ewowi/StarMod/commits/main
+   @Copyright (c) 2024 Github StarMod Commit Authors
+   @license   GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007
+   @license   For non GPL-v3 usage, commercial licenses must be purchased. Contact moonmodules@icloud.com
+*/
+
+// This is a collection of ESP32 specific low-level functions.
+
+bool sysTools_normal_startup(void);              // FALSE if unusual startup code --> use next function to get more info
+String sysTools_getRestartReason(void);          // long string including restart codes from system, Core#0 and Core#1 (if availeable)
+
+int sysTools_get_arduino_maxStackUsage(void);    // to query max used stack of the arduino task. returns "-1" if unknown
+int sysTools_get_webserver_maxStackUsage(void);  // to query max used stack of the webserver task. returns "-1" if unknown

--- a/src/Sys/esp32Tools.h
+++ b/src/Sys/esp32Tools.h
@@ -14,5 +14,8 @@
 bool sysTools_normal_startup(void);              // FALSE if unusual startup code --> use next function to get more info
 String sysTools_getRestartReason(void);          // long string including restart codes from system, Core#0 and Core#1 (if availeable)
 
+String sysTools_restart2String(int reasoncode);  // helper for SysModSystem::addRestartReasonsSelect. Returns "(#) ReasonText"
+String sysTools_reset2String(int resetCode);     // helper for SysModSystem::addResetReasonsSelect. Returns "shortResetReasonText (#)"
+
 int sysTools_get_arduino_maxStackUsage(void);    // to query max used stack of the arduino task. returns "-1" if unknown
 int sysTools_get_webserver_maxStackUsage(void);  // to query max used stack of the webserver task. returns "-1" if unknown


### PR DESCRIPTION
### Serial Debug improvement
Lolin S2 mini does not expose the standard RX/TX pins, so it was impossible to get a crashdump via serial-to-usb module.
* Workaround: re-init Serial using pins defined by arduino variant
* use newer Framework (arduino-esp32 2.0.9) that does not block if USB-CDC is unconnected

### esp32Tools
* adding esp32Tools for collecting esp32 specific support functions. The interface in esp32tools.h is generic to allow porting to other platforms. System tools for esp32 are based on WLEDMM source code, and compatible with all esp32 variants.

* The concept could be extended later, to collect all platform specific stuff in a separate "platforms" directory - Similar to fastLED.

* As some crashes happen "silently", add a crash warning to Serial output on startup:

```
Rebooting...
WARNING - possible crash: (code 4) Software reset due to panic or unhandled exception (SW error). Core#0 (code 3) SW reset.
Ready.
```
