### PR TITLE
C3 support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -108,6 +108,16 @@ build_flags =
   -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
 
 
+[env:pico32]
+board = pico32 ;https://github.com/platformio/platform-espressif32/blob/develop/boards/pico32.json
+; recommended to pin to a platform version, see https://github.com/platformio/platform-espressif32/releases
+platform = espressif32@6.5.0 ;using platformio/framework-arduinoespressif32 @ ~3.20014.0 / framework-arduinoespressif32 @ 3.20014.231204 (2.0.14)
+upload_speed = 230400  ;; reduced speed, as a manually attached serial-to-USB Module is needed on most pico boards (flimsy cables -> not reliable connection)
+build_flags = 
+  ${env.build_flags}
+  -DCONFIG_IDF_TARGET_ESP32=1
+  -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
+
 
 [env:lolin_d32]
 board = lolin_d32 ;https://github.com/platformio/platform-espressif32/blob/develop/boards/lolin_d32.json (no differences with esp32dev)

--- a/platformio.ini
+++ b/platformio.ini
@@ -84,7 +84,6 @@ build_flags =
   ${starmod.build_flags}
   -DCONFIG_ASYNC_TCP_USE_WDT=0
   -DLFS_THREADSAFE            ;; enables use of semaphores in LittleFS driver
-  -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
   ${appmod_leds.build_flags}
   ${usermod_e131.build_flags}
   ; ${usermod_ha.build_flags}
@@ -106,6 +105,7 @@ upload_speed = 1500000
 build_flags = 
   ${env.build_flags}
   -DCONFIG_IDF_TARGET_ESP32=1
+  -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
 
 
 
@@ -116,6 +116,7 @@ platform = espressif32@6.5.0 ;using platformio/framework-arduinoespressif32 @ ~3
 build_flags = 
   ${env.build_flags}
   -DCONFIG_IDF_TARGET_ESP32=1
+  -DARDUINO_USB_CDC_ON_BOOT=0 ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (needed on "classic ESP32")
 
 
 
@@ -134,6 +135,20 @@ build_flags = ${env.build_flags}
   ; -D DEBUG=1 -D CORE_DEBUG_LEVEL=1 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
 
 
+[env:lolin_c3_mini]
+board = lolin_c3_mini ;https://github.com/platformio/platform-espressif32/blob/develop/boards/lolin_c3_mini.json
+;; platform = espressif32@5.3.0 ;; WLED default framework version
+platform = espressif32@6.3.0    ;; this one behaves better for debugging
+upload_speed = 256000
+build_unflags =
+  ; -DARDUINO_USB_CDC_ON_BOOT=1 ;; un-comment if you want to use a "real" serial-to-USB moddule !!!! make sure =0 and not =1 is uncommented!!
+build_flags = ${env.build_flags}
+  -DDCONFIG_IDF_TARGET_ESP32C3=1
+  -DARDUINO_USB_CDC_ON_BOOT=1   ;; for debugging over USB
+  ; -DARDUINO_USB_CDC_ON_BOOT=0 ;; with serial-to-USB moddule (use in case your board hangs without USB connection)
+  -DARDUINO_USB_MODE=1        ;; Make sure that the right HardwareSerial driver is picked in arduino-esp32 (mandatory on -C3)
+  -DLOLIN_WIFI_FIX            ;; activate workaround for LOLIN C3/S2/S3 wifi instability. https://www.wemos.cc/en/latest/c3/c3_mini_1_0_0.html#about-wifi
+  ; -D DEBUG=1 -D CORE_DEBUG_LEVEL=1 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,7 +68,7 @@ lib_deps =
 build_flags = 
   -D USERMOD_WLEDAUDIO
 lib_deps =
-    https://github.com/netmindz/WLED-sync#v0.14.0.b16    
+    https://github.com/netmindz/WLED-sync#07737aff9523a615f507b9525ffe55c98c440f8f ;; fixes 'Could not parse manifest' warning
 
 
 

--- a/src/App/AppModLeds.h
+++ b/src/App/AppModLeds.h
@@ -291,8 +291,11 @@ public:
                 case 13: FastLED.addLeds<NEOPIXEL, 13>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 14: FastLED.addLeds<NEOPIXEL, 14>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 15: FastLED.addLeds<NEOPIXEL, 15>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !defined(BOARD_HAS_PSRAM) && !defined(ARDUINO_ESP32_PICO)
+                // 16+17 = reserved for PSRAM, or reserved for FLASH on pico-D4
                 case 16: FastLED.addLeds<NEOPIXEL, 16>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 17: FastLED.addLeds<NEOPIXEL, 17>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
                 case 18: FastLED.addLeds<NEOPIXEL, 18>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 19: FastLED.addLeds<NEOPIXEL, 19>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 20: FastLED.addLeds<NEOPIXEL, 20>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
@@ -309,23 +312,13 @@ public:
                 // case 31: FastLED.addLeds<NEOPIXEL, 31>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 32: FastLED.addLeds<NEOPIXEL, 32>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 33: FastLED.addLeds<NEOPIXEL, 33>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // 34-39 input-only
                 // case 34: FastLED.addLeds<NEOPIXEL, 34>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 35: FastLED.addLeds<NEOPIXEL, 35>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 36: FastLED.addLeds<NEOPIXEL, 36>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 37: FastLED.addLeds<NEOPIXEL, 37>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 38: FastLED.addLeds<NEOPIXEL, 38>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 39: FastLED.addLeds<NEOPIXEL, 39>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 40: FastLED.addLeds<NEOPIXEL, 40>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 41: FastLED.addLeds<NEOPIXEL, 41>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 42: FastLED.addLeds<NEOPIXEL, 42>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 43: FastLED.addLeds<NEOPIXEL, 43>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 44: FastLED.addLeds<NEOPIXEL, 44>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 45: FastLED.addLeds<NEOPIXEL, 45>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 46: FastLED.addLeds<NEOPIXEL, 46>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 47: FastLED.addLeds<NEOPIXEL, 47>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 48: FastLED.addLeds<NEOPIXEL, 48>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 49: FastLED.addLeds<NEOPIXEL, 49>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 50: FastLED.addLeds<NEOPIXEL, 50>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
               #endif //CONFIG_IDF_TARGET_ESP32
 
               #if CONFIG_IDF_TARGET_ESP32S2
@@ -348,13 +341,19 @@ public:
                 case 16: FastLED.addLeds<NEOPIXEL, 16>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 17: FastLED.addLeds<NEOPIXEL, 17>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 18: FastLED.addLeds<NEOPIXEL, 18>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !ARDUINO_USB_CDC_ON_BOOT
+                // 19 + 20 = USB HWCDC. reserved for USB port when ARDUINO_USB_CDC_ON_BOOT=1
                 case 19: FastLED.addLeds<NEOPIXEL, 19>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 20: FastLED.addLeds<NEOPIXEL, 20>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
                 case 21: FastLED.addLeds<NEOPIXEL, 21>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // 22 to 32: not connected, or reserved for SPI FLASH
                 // case 22: FastLED.addLeds<NEOPIXEL, 22>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 23: FastLED.addLeds<NEOPIXEL, 23>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 24: FastLED.addLeds<NEOPIXEL, 24>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 25: FastLED.addLeds<NEOPIXEL, 25>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !defined(BOARD_HAS_PSRAM)
+                // 26-32 = reserved for PSRAM
                 case 26: FastLED.addLeds<NEOPIXEL, 26>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 27: FastLED.addLeds<NEOPIXEL, 27>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 28: FastLED.addLeds<NEOPIXEL, 28>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
@@ -362,6 +361,7 @@ public:
                 // case 30: FastLED.addLeds<NEOPIXEL, 30>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 31: FastLED.addLeds<NEOPIXEL, 31>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 // case 32: FastLED.addLeds<NEOPIXEL, 32>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
                 case 33: FastLED.addLeds<NEOPIXEL, 33>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 34: FastLED.addLeds<NEOPIXEL, 34>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 35: FastLED.addLeds<NEOPIXEL, 35>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
@@ -375,12 +375,38 @@ public:
                 case 43: FastLED.addLeds<NEOPIXEL, 43>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 44: FastLED.addLeds<NEOPIXEL, 44>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
                 case 45: FastLED.addLeds<NEOPIXEL, 45>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // 46 input-only
                 // case 46: FastLED.addLeds<NEOPIXEL, 46>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 47: FastLED.addLeds<NEOPIXEL, 47>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 48: FastLED.addLeds<NEOPIXEL, 48>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 49: FastLED.addLeds<NEOPIXEL, 49>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 50: FastLED.addLeds<NEOPIXEL, 50>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
-                // case 51: FastLED.addLeds<NEOPIXEL, 51>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+              #endif //CONFIG_IDF_TARGET_ESP32S2
+
+              #if CONFIG_IDF_TARGET_ESP32C3
+                case 0: FastLED.addLeds<NEOPIXEL, 0>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 1: FastLED.addLeds<NEOPIXEL, 1>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 2: FastLED.addLeds<NEOPIXEL, 2>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 3: FastLED.addLeds<NEOPIXEL, 3>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 4: FastLED.addLeds<NEOPIXEL, 4>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 5: FastLED.addLeds<NEOPIXEL, 5>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 6: FastLED.addLeds<NEOPIXEL, 6>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 7: FastLED.addLeds<NEOPIXEL, 7>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 8: FastLED.addLeds<NEOPIXEL, 8>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 9: FastLED.addLeds<NEOPIXEL, 9>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 10: FastLED.addLeds<NEOPIXEL, 10>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // 11-17 reserved for SPI FLASH
+                //case 11: FastLED.addLeds<NEOPIXEL, 11>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 12: FastLED.addLeds<NEOPIXEL, 12>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 13: FastLED.addLeds<NEOPIXEL, 13>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 14: FastLED.addLeds<NEOPIXEL, 14>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 15: FastLED.addLeds<NEOPIXEL, 15>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 16: FastLED.addLeds<NEOPIXEL, 16>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                //case 17: FastLED.addLeds<NEOPIXEL, 17>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !ARDUINO_USB_CDC_ON_BOOT
+                // 18 + 19 = USB HWCDC. reserved for USB port when ARDUINO_USB_CDC_ON_BOOT=1
+                case 18: FastLED.addLeds<NEOPIXEL, 18>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 19: FastLED.addLeds<NEOPIXEL, 19>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
+                // 20+21 = Serial RX+TX --> don't use for LEDS when serial-to-USB is needed
+                case 20: FastLED.addLeds<NEOPIXEL, 20>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 21: FastLED.addLeds<NEOPIXEL, 21>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
               #endif //CONFIG_IDF_TARGET_ESP32S2
 
               default: USER_PRINTF("FastLedPin assignment: pin not supported %d\n", pinNr);


### PR DESCRIPTION
pio
* new environment for -C3
* moved ARDUINO_USB_CDC_ON_BOOT=0 out of [env], as this flag is meant for "classic esp32" and may cause conflicts on other variants.
* new buildenv for esp32 "pico32" board (not a -C3, but a bit special)
* update WLED-Sync (due to broken `library.json`)

AppModLeds:
* allowed pins on -C3
* some pin cleanups and corrections for esp32, esp32-S2
