### PR TITLE
S3mini support, and avoiding dangerous pins on -C3/-S2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -139,7 +139,6 @@ upload_speed = 256000
 build_flags = 
   ${env.build_flags}
   ; -DARDUINO_ARCH_ESP32 ; no proof of necessity yet...
-  ; -DARDUINO_ARCH_ESP32S3 ; no proof of necessity yet...
   -DCONFIG_IDF_TARGET_ESP32S2=1
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; for debugging over USB
   ; -DARDUINO_USB_CDC_ON_BOOT=0 -DARDUINO_USB_DFU_ON_BOOT=1 -DARDUINO_USB_MSC_ON_BOOT=0 ;; with serial-to-USB moddule (use in case your board hangs without USB connection)
@@ -165,7 +164,20 @@ build_flags =
   ; -D DEBUG=1 -D CORE_DEBUG_LEVEL=1 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
 
 
-
+;; for Waveshare ESP32-S3 Mini/Zero https://www.waveshare.com/esp32-s3-zero.htm
+;; --> 4MB Flash, has PSRAM, memory type "qio_qspi", USB-CDC only
+[env:esp32_s3_mini]
+platform = espressif32@6.3.0    ;; this one behaves better for debugging
+board = lolin_s3_mini ;https://github.com/platformio/platform-espressif32/blob/develop/boards/lolin_s3_mini.json
+upload_speed = 256000
+build_unflags =
+  -DNDEBUG
+build_flags =
+  ${env.build_flags}
+  -DCONFIG_IDF_TARGET_ESP32S3=1
+  -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1 -DARDUINO_USB_DFU_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 ;; for debugging over USB
+  -D DEBUG=1 -D CORE_DEBUG_LEVEL=5 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
+  ;;-DSTARMOD_LOLIN_WIFI_FIX  ;; I don't trust the tiny ceramic antenna - use workaround for LOLIN C3/S2/S3 wifi instability. https://www.wemos.cc/en/latest/c3/c3_mini_1_0_0.html#about-wifi
 
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -170,14 +170,12 @@ build_flags =
 platform = espressif32@6.3.0    ;; this one behaves better for debugging
 board = lolin_s3_mini ;https://github.com/platformio/platform-espressif32/blob/develop/boards/lolin_s3_mini.json
 upload_speed = 256000
-build_unflags =
-  -DNDEBUG
 build_flags =
   ${env.build_flags}
   -DCONFIG_IDF_TARGET_ESP32S3=1
   -DARDUINO_USB_CDC_ON_BOOT=1 -DARDUINO_USB_MODE=1 -DARDUINO_USB_DFU_ON_BOOT=0 -DARDUINO_USB_MSC_ON_BOOT=0 ;; for debugging over USB
-  -D DEBUG=1 -D CORE_DEBUG_LEVEL=5 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
-  ;;-DSTARMOD_LOLIN_WIFI_FIX  ;; I don't trust the tiny ceramic antenna - use workaround for LOLIN C3/S2/S3 wifi instability. https://www.wemos.cc/en/latest/c3/c3_mini_1_0_0.html#about-wifi
+  ; -D DEBUG=1 -D CORE_DEBUG_LEVEL=1 -D ARDUINOJSON_DEBUG=1 ;; for more debug output
+  ; -DSTARMOD_LOLIN_WIFI_FIX  ;; I don't trust the tiny ceramic antenna - use workaround for LOLIN C3/S2/S3 wifi instability. https://www.wemos.cc/en/latest/c3/c3_mini_1_0_0.html#about-wifi
 
 
 

--- a/src/App/AppModFixtureGen.h
+++ b/src/App/AppModFixtureGen.h
@@ -565,10 +565,24 @@ public:
       default: return false; 
     }}); //fixtureGen
 
-    ui->initText(parentVar, "pinList", "16", 32, false, [](JsonObject var, uint8_t rowNr, uint8_t funType) { switch (funType) { //varFun
+	// gpio2 seems to be a safe choice on all esp32 variants
+    ui->initText(parentVar, "pinList", "2", 32, false, [](JsonObject var, uint8_t rowNr, uint8_t funType) { switch (funType) { //varFun
       case f_UIFun:
         ui->setComment(var, "One or more e.g. 12,13,14");
         return true;
+#if 0		// @ewowi did not get this to work
+      case f_ValueFun:
+        #if CONFIG_IDF_TARGET_ESP32 && (defined(BOARD_HAS_PSRAM) || defined(ARDUINO_ESP32_PICO)) // 
+          ui->setValue(var, "2");  // gpio16 is reserved on pico and on esp32 with PSRAM
+        #elif CONFIG_IDF_TARGET_ESP32S3
+          ui->setValue(var, "21");  // gpio21 = builtin neopixel on some -S3 boards
+        #elif CONFIG_IDF_TARGET_ESP32C3
+          ui->setValue(var, "10");  // gpio10 = builtin neopixel on some -C3 boards
+        #else
+          ui->setValue(var, "16");  // default on universal shield (classic esp32, or esp32-S2)
+        #endif
+        return true;
+#endif
       default: return false;
     }});
 

--- a/src/App/AppModLeds.h
+++ b/src/App/AppModLeds.h
@@ -466,6 +466,66 @@ public:
                 case 21: FastLED.addLeds<NEOPIXEL, 21>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
               #endif //CONFIG_IDF_TARGET_ESP32S2
 
+              #if CONFIG_IDF_TARGET_ESP32S3
+                case 0: FastLED.addLeds<NEOPIXEL, 0>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 1: FastLED.addLeds<NEOPIXEL, 1>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 2: FastLED.addLeds<NEOPIXEL, 2>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 3: FastLED.addLeds<NEOPIXEL, 3>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 4: FastLED.addLeds<NEOPIXEL, 4>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 5: FastLED.addLeds<NEOPIXEL, 5>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 6: FastLED.addLeds<NEOPIXEL, 6>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 7: FastLED.addLeds<NEOPIXEL, 7>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 8: FastLED.addLeds<NEOPIXEL, 8>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 9: FastLED.addLeds<NEOPIXEL, 9>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 10: FastLED.addLeds<NEOPIXEL, 10>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 11: FastLED.addLeds<NEOPIXEL, 11>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 12: FastLED.addLeds<NEOPIXEL, 12>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 13: FastLED.addLeds<NEOPIXEL, 13>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 14: FastLED.addLeds<NEOPIXEL, 14>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 15: FastLED.addLeds<NEOPIXEL, 15>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 16: FastLED.addLeds<NEOPIXEL, 16>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 17: FastLED.addLeds<NEOPIXEL, 17>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 18: FastLED.addLeds<NEOPIXEL, 18>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !ARDUINO_USB_CDC_ON_BOOT
+                // 19 + 20 = USB-JTAG. Not recommended for other uses.
+                case 19: FastLED.addLeds<NEOPIXEL, 19>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 20: FastLED.addLeds<NEOPIXEL, 20>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
+                case 21: FastLED.addLeds<NEOPIXEL, 21>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // // 22 to 32: not connected, or SPI FLASH
+                // case 22: FastLED.addLeds<NEOPIXEL, 22>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 23: FastLED.addLeds<NEOPIXEL, 23>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 24: FastLED.addLeds<NEOPIXEL, 24>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 25: FastLED.addLeds<NEOPIXEL, 25>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 26: FastLED.addLeds<NEOPIXEL, 26>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 27: FastLED.addLeds<NEOPIXEL, 27>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 28: FastLED.addLeds<NEOPIXEL, 28>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 29: FastLED.addLeds<NEOPIXEL, 29>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 30: FastLED.addLeds<NEOPIXEL, 30>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 31: FastLED.addLeds<NEOPIXEL, 31>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // case 32: FastLED.addLeds<NEOPIXEL, 32>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #if !defined(BOARD_HAS_PSRAM)
+                // 33 to 37: reserved if using _octal_ SPI Flash or _octal_ PSRAM
+                case 33: FastLED.addLeds<NEOPIXEL, 33>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 34: FastLED.addLeds<NEOPIXEL, 34>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 35: FastLED.addLeds<NEOPIXEL, 35>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 36: FastLED.addLeds<NEOPIXEL, 36>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 37: FastLED.addLeds<NEOPIXEL, 37>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+            #endif
+                case 38: FastLED.addLeds<NEOPIXEL, 38>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 39: FastLED.addLeds<NEOPIXEL, 39>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 40: FastLED.addLeds<NEOPIXEL, 40>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 41: FastLED.addLeds<NEOPIXEL, 41>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 42: FastLED.addLeds<NEOPIXEL, 42>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                // 43+44 = Serial RX+TX --> don't use for LEDS when serial-to-USB is needed
+                case 43: FastLED.addLeds<NEOPIXEL, 43>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 44: FastLED.addLeds<NEOPIXEL, 44>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 45: FastLED.addLeds<NEOPIXEL, 45>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 46: FastLED.addLeds<NEOPIXEL, 46>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 47: FastLED.addLeds<NEOPIXEL, 47>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+                case 48: FastLED.addLeds<NEOPIXEL, 48>(fixture.ledsP, startLed, nrOfLeds).setCorrection(TypicalLEDStrip); break;
+              #endif //CONFIG_IDF_TARGET_ESP32S3
+
               default: USER_PRINTF("FastLedPin assignment: pin not supported %d\n", pinNr);
             }
           }

--- a/src/Sys/SysModPins.h
+++ b/src/Sys/SysModPins.h
@@ -12,7 +12,7 @@
 #pragma once
 #include "SysModule.h"
 
-#define NUM_PINS 50
+#define NUM_PINS NUM_DIGITAL_PINS // softhack007 NUM_DIGITAL_PINS comes from the arduino framework
 
 //info stored per pin
 struct PinObject {


### PR DESCRIPTION
platformio.ini: new buildenv for esp32-S3 Mini/Zero with 4MB flash and 2MB PSRAM

AppModLeds: FastLED pins for -S3

AppModFixtureGen: change default LED pin 16 --> 2 (safe choice on all boards)

SysModPins: 
* some improvements by using macros from arduino framework: NUM_DIGITAL_PINS and digitalPinIsValid()
* disable dangerous direct pin access on -S2-/-C3/-S3