### PR TITLE
check if node is in the path before building the webui .h files

### DIFF
--- a/tools/webbundle.py
+++ b/tools/webbundle.py
@@ -1,11 +1,20 @@
 Import("env")
+import shutil
 
-# Install the necessary node packages for the pre-build asset bundling script
-env.Execute("npm install")
+cmd_ex = shutil.which("node")
+# Check if Node.js is not installed
+if cmd_ex is None:
+    print('\x1b[0;31;43m' + 'Node.js is not installed or missing from PATH changes to html css js will not be processed' + '\x1b[0m')
+else:
+    # Install the necessary node packages for the pre-build asset bundling script
+    print('\x1b[6;33;42m' + 'Install the node packages' + '\x1b[0m')
 
-# Call the bundling script
-exitCode = env.Execute("node tools/cdata.js")
+    # npm ci performs a clean install of all existing dependencies
+    env.Execute("npm ci")
 
-# If it failed, abort the build
-if (exitCode):
-  Exit(exitCode)
+    # Call the bundling script
+    exitCode = env.Execute("node tools/cdata.js")
+
+    # If it failed, abort the build
+    if (exitCode):
+      Exit(exitCode)


### PR DESCRIPTION
This will need to show only error that node is not installed or missing from the PATH and continue with the build not cancelling if `node` is missing

![image](https://github.com/user-attachments/assets/932c30da-904a-45e3-81ea-028e1e0c7cac)
